### PR TITLE
The change is to facilitate shader code reading in vs. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,34 @@ cmake_minimum_required(VERSION 3.10.2)
 
 project(vk_cooperative_matrix_perf)
 
+set(TARGET_NAME "vk_cooperative_matrix_perf")
+
+set(BENCHMARK_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin CACHE STRING "Binary Dir" FORCE) #force update even if it in cache
+message(STATUS "BENCHMARK_BINARY_DIR='${TUTORIAL_BINARY_DIR}' ")
+
+# Create the directory if it does not exist
+file(MAKE_DIRECTORY ${BENCHMARK_BINARY_DIR})
+
 find_package(Vulkan REQUIRED)
 
 include_directories(${Vulkan_INCLUDE_DIR})
 
-add_executable(vk_cooperative_matrix_perf src/vk_cooperative_matrix_perf.cpp)
+file( GLOB SHADER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/shaders/*.comp )
+foreach(shader ${SHADER_FILES})
+    set_source_files_properties( ${shader} PROPERTIES HEADER_FILE_ONLY TRUE )
+endforeach()
 
-target_link_libraries(vk_cooperative_matrix_perf ${Vulkan_LIBRARY})
+add_executable(${TARGET_NAME} src/vk_cooperative_matrix_perf.cpp ${SHADER_FILES})
+
+target_link_libraries(${TARGET_NAME} ${Vulkan_LIBRARY})
+
+set_target_properties(${TARGET_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG ${BENCHMARK_BINARY_DIR})
+set_target_properties(${TARGET_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE ${BENCHMARK_BINARY_DIR})
+set_target_properties(${TARGET_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${BENCHMARK_BINARY_DIR})
+set_target_properties(${TARGET_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY ${BENCHMARK_BINARY_DIR})
+set_target_properties(${TARGET_NAME} PROPERTIES DEBUG_POSTFIX "_d")
+set_target_properties(${TARGET_NAME} PROPERTIES RELWITHDEBINFO_POSTFIX "RelWithDebInfo")
+
+file( GLOB SPV_FILES ${CMAKE_CURRENT_SOURCE_DIR}/shaders/*.spv )
+file( COPY ${SPV_FILES}  DESTINATION ${BENCHMARK_BINARY_DIR}/shaders/)
+message(STATUS "copy SPIR-V file into ${BENCHMARK_BINARY_DIR}/shaders/...") 


### PR DESCRIPTION
The change serves 2 purposes:

- Auto copy spir-v file and target exe to the same dir.
- Make Shader source code appears in vs solution explorer.