### PR TITLE
Skip cooperative-matrix combinations with no bundled shader

### DIFF
--- a/src/vk_cooperative_matrix_perf.cpp
+++ b/src/vk_cooperative_matrix_perf.cpp
@@ -990,8 +990,8 @@ int main(int argc, char *argv[])
         std::ifstream spirvfile(fileName.c_str(), std::ios::binary | std::ios::ate);
         std::streampos spirvsize = spirvfile.tellg();
         if ((int)spirvsize == -1) {
-            printf("%s not found!\n", fileName.c_str());
-            throw;
+            printf("SKIP: %s not found (no precompiled shader for this advertised combo)\n", fileName.c_str());
+            continue;
         }
         spirvfile.seekg(0, std::ios::beg);
 


### PR DESCRIPTION

The shader-loading loop builds a filename from each driver-advertised cooperative-matrix property and, when the
matching `.spv` is missing, prints `<file> not found!` and runs a bare `throw;`. With no exception in flight that
calls `std::terminate()` (*"terminate called without an active exception"*) and aborts the whole run.

A driver can legitimately advertise type combinations the bundled shader set doesn't cover. Concretely, RADV
(Mesa) on RDNA4 with `VK_NV_cooperative_matrix2` **workgroup scope** advertises the mixed-sign integer combos
`u8 → s32` and `s8 → u32`, for which there is no `workgroupu8_s32.spv` / `workgroups8_u32.spv` (only `s8_s32` and
`u8_u32` ship). The tool terminates at the first such combo, before it can test everything it does support.

This prints a `SKIP:` notice and `continue`s to the next property instead, so the run completes over the
combinations that have shaders:

```diff
         if ((int)spirvsize == -1) {
-            printf("%s not found!\n", fileName.c_str());
-            throw;
+            printf("SKIP: %s not found (no precompiled shader for this advertised combo)\n", fileName.c_str());
+            continue;
         }
```

With this the abort is gone: `--correctness` runs to completion on RADV/RDNA4 (3356/3356 configurations pass),
and `--benchmark` continues past the missing combo through the shader set instead of terminating.

<sub>Tested on RX 9070 XT (RADV `GFX1201`). AI-assisted (Claude Code), reviewed by me.</sub>

