### PR TITLE
Throw a real exception (not a bare throw) on Vulkan errors

### DIFF
--- a/src/vk_cooperative_matrix_perf.cpp
+++ b/src/vk_cooperative_matrix_perf.cpp
@@ -24,6 +24,7 @@
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
+#include <stdexcept>
 #include <fstream>
 #include <map>
 #include <vector>
@@ -72,8 +73,8 @@ using std::vector;
 
 #define CHECK_RESULT(r) do {    \
     if ((r) != VK_SUCCESS) {    \
-        printf("result = %d, line = %d\n", (r), __LINE__);  \
-        throw;  \
+        fprintf(stderr, "CHECK_RESULT failed: VkResult %d at %s:%d\n", (r), __FILE__, __LINE__);  \
+        throw std::runtime_error("Vulkan call failed");  \
     }   \
 } while (0)
 


### PR DESCRIPTION

`CHECK_RESULT` reports a failed Vulkan call with a bare `throw;`:

```cpp
#define CHECK_RESULT(r) do {    \
    if ((r) != VK_SUCCESS) {    \
        printf("result = %d, line = %d\n", (r), __LINE__);  \
        throw;  \
    }   \
} while (0)
```

A bare `throw;` rethrows the *currently-handled* exception, but `CHECK_RESULT` is never invoked from within a
`catch`, so there is no exception in flight and it calls `std::terminate()` — *"terminate called without an
active exception"* — an uninformative abort. The diagnostic is also printed to stdout, which is block-buffered when redirected
(CI, log capture) and is not flushed by `abort()`, so the message is easily lost as well.

This prints the failing `VkResult` and location to stderr (unbuffered) and throws a real exception instead:

```diff
 #include <cstdlib>
+#include <stdexcept>
 #include <fstream>
...
     if ((r) != VK_SUCCESS) {    \
-        printf("result = %d, line = %d\n", (r), __LINE__);  \
-        throw;  \
+        fprintf(stderr, "CHECK_RESULT failed: VkResult %d at %s:%d\n", (r), __FILE__, __LINE__);  \
+        throw std::runtime_error("Vulkan call failed");  \
     }   \
```

Now a failed Vulkan call reports clearly on stderr — `CHECK_RESULT failed: VkResult <code> at <file>:<line>` —
instead of aborting with no message.

<sub>AI-assisted (Claude Code), reviewed by me.</sub>

