### PR TITLE
Enable subgroupSizeControl and computeFullSubgroups features

### DIFF
--- a/src/vk_cooperative_matrix_perf.cpp
+++ b/src/vk_cooperative_matrix_perf.cpp
@@ -728,6 +728,8 @@ int main(int argc, char *argv[])
 
     VkPhysicalDeviceVulkan13Features vulkan13Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES, &vulkan12Features };
     vulkan13Features.maintenance4 = VK_TRUE;
+    vulkan13Features.subgroupSizeControl = VK_TRUE;
+    vulkan13Features.computeFullSubgroups = VK_TRUE;
 
     std::vector<const char *> enabledDeviceExtensions = { VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME, };
     if (coopmat2Supported) {


### PR DESCRIPTION
Each compute pipeline requests specific subgroup behaviour per stage: it chains a
`VkPipelineShaderStageRequiredSubgroupSizeCreateInfo` onto the stage (a required subgroup size of 32) and sets
`VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT` in the stage flags. But the device is created
without enabling the two features that make those requests legal — `subgroupSizeControl` (required to chain
`…RequiredSubgroupSizeCreateInfo`) and `computeFullSubgroups` (required for `REQUIRE_FULL_SUBGROUPS_BIT`). Under
`VK_LAYER_KHRONOS_validation` this trips two VUIDs on every `vkCreateComputePipelines`:

```
VUID-VkPipelineShaderStageCreateInfo-pNext-02755: …RequiredSubgroupSizeCreateInfo… the subgroupSizeControl feature was not enabled
VUID-VkPipelineShaderStageCreateInfo-flags-02785: …REQUIRE_FULL_SUBGROUPS_BIT… the computeFullSubgroups feature was not enabled
```

This isn't only validation noise. With the features off, both requests are invalid usage, so the spec doesn't
guarantee the requested subgroup size or full-subgroup behaviour the tool depends on — enabling the features is
what actually makes its existing requests well-defined, not just a way to silence the messages. As a side
benefit, when the tool is used as a harness to validate a driver's cooperative-matrix support under VVL, these
two self-inflicted violations stop firing on every pipeline, so genuine driver findings stand out instead of
being buried.

Both features are Vulkan 1.3 core (promoted from `VK_EXT_subgroup_size_control`) and live in the
`VkPhysicalDeviceVulkan13Features` struct already chained into the device-create info, so the fix is two lines:

```diff
     VkPhysicalDeviceVulkan13Features vulkan13Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES, &vulkan12Features };
     vulkan13Features.maintenance4 = VK_TRUE;
+    vulkan13Features.subgroupSizeControl = VK_TRUE;
+    vulkan13Features.computeFullSubgroups = VK_TRUE;
```

Verified on RADV (`GFX1201`) under `VK_LAYER_KHRONOS_validation`: the two VUIDs, which previously fired on every
compute pipeline (40 reports across a `--correctness` run), drop to zero, and `--correctness` still passes
3356/3356 with no regression.

<sub>Tested on RX 9070 XT (RADV `GFX1201`). AI-assisted (Claude Code), reviewed by me.</sub>
