### PR TITLE
Only launch workgroup-scope matrices at the advertised workgroupInvocations

### DIFF
--- a/src/vk_cooperative_matrix_perf.cpp
+++ b/src/vk_cooperative_matrix_perf.cpp
@@ -1123,6 +1123,24 @@ int main(int argc, char *argv[])
                 if (workgroupSize != 128 && workgroupSize != 256) {
                     continue;
                 }
+                // The same type may be advertised at several workgroup sizes as
+                // separate flexible properties; only run the advertised ones.
+                {
+                    bool supported = false;
+                    for (uint32_t j = 0; j < numCooperativeMatrixFlexibleDimensionsProperties; ++j) {
+                        const VkCooperativeMatrixFlexibleDimensionsPropertiesNV *other = &cooperativeMatrixFlexibleDimensionsProperties[j];
+                        if (other->scope == VK_SCOPE_WORKGROUP_KHR &&
+                            other->AType == AType && other->BType == BType &&
+                            other->CType == CType && other->ResultType == ResultType &&
+                            other->workgroupInvocations == workgroupSize) {
+                            supported = true;
+                            break;
+                        }
+                    }
+                    if (!supported) {
+                        continue;
+                    }
+                }
                 break;
             case TT_SHARED:
                 if (workgroupSize != 256) {


### PR DESCRIPTION
The workgroup-scope test loop tries both `workgroupSize = 128` and `256` for every property, but a
workgroup-scope cooperative matrix has to be launched with exactly the property's `workgroupInvocations`. The
benchmark never reads that field, so on a device that only advertises one workgroup size it ends up launching an
unsupported one.

I ran into this on RADV (Mesa, RX 9070 XT / RDNA 4, `VK_NV_cooperative_matrix2`), where every workgroup-scope
flexible property advertises `workgroupInvocations = 256` and there is no 128 variant. The `workgroupSize = 128`
pipelines then request a matrix no property supports.

It first surfaced as a validation error, `VUID-RuntimeSpirv-cooperativeMatrixFlexibleDimensions-10166` and
`-10165`, which I'd reported as a layer false positive in
[KhronosGroup/Vulkan-ValidationLayers#12363](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12363).
It turned out the layer was right: it resolves the specialized local size correctly and rejects the 128-thread
launch because no advertised workgroup-scope property matches it. Thanks for pointing that out in the issue, the
fix belongs here.

The fix is two small changes. First, it captures each flexible property's `workgroupInvocations` and launches the
workgroup-scope tests at exactly that size, instead of hardcoding `{128, 256}`. Second, it adds
`workgroupInvocations` to the property-dedup key, so a matrix that's advertised at more than one workgroup size
(say both 128 and 256) is kept as separate entries and each is tested at its own size, instead of the dedup
collapsing them to one. On a device that advertises a single workgroup size per type (like RADV), that second
change is a no-op.

Verified on RADV (GFX1201, Mesa coopmat2) under `VK_LAYER_KHRONOS_validation` with
`duplicate_message_limit = 0`: VUID-10166 / -10165 go from 136 / 408 to 0, the unsupported `wg=128` workgroup
configs are skipped, the valid `wg=256` ones still run, and `--correctness` passes 3288 / 3288 (was 3356 / 3356;
the 68 fewer are exactly the unsupported launches).

Tested on RX 9070 XT (RADV GFX1201). AI-assisted (Claude Code), reviewed by me.
